### PR TITLE
Fix: Fix timestamp which led to premature update

### DIFF
--- a/src/renderer/ts/Renderable.ts
+++ b/src/renderer/ts/Renderable.ts
@@ -111,7 +111,7 @@ export default class Renderable implements Drawable {
     this.frameCount = frameCount;
     this.gridRatio = gridRatio;
     this.fps = fps;
-    this.nextAnimationTimestamp = new Date().getTime();
+    this.nextAnimationTimestamp = new Date().getTime() + 1000 / this.fps;
 
     this.img.onload = () => {
       this.spriteSize = new Vector(


### PR DESCRIPTION
In renderable a bug existed where nextAnimationTimestamp was not set to the correct time.
@adalfonso #6 